### PR TITLE
fix(proxy): handling of false-like initial value

### DIFF
--- a/trame_simput/core/proxy.py
+++ b/trame_simput/core/proxy.py
@@ -96,10 +96,8 @@ class Proxy:
                 self.set_property(_prop_name, kwargs[_prop_name])
             elif isinstance(_init_def, dict):
                 logger.error("Don't know how to deal with domain yet: %s", _init_def)
-            elif _init_def:
-                self.set_property(_prop_name, _init_def)
             else:
-                self.set_property(_prop_name, None)
+                self.set_property(_prop_name, _init_def)
 
         # handle domains
         for _prop_name, _prop_def in self.definition.items():


### PR DESCRIPTION
Currently, if the initial value for a property is falsy, then it is initialized to `None`. This prevents values like `False` or `0` from working properly.

We already set `_init_def` to `None` if no initial value exists, so `_init_def` can safely be passed to `set_property()` without further checks.