### PR TITLE
fix(proxy): Log warning if no defintion was found in set_property

### DIFF
--- a/trame_simput/core/proxy.py
+++ b/trame_simput/core/proxy.py
@@ -213,7 +213,11 @@ class Proxy:
     def set_property(self, name, value):
         """Update a property on that proxy"""
         # convert any invalid indirect value (proxy)
-        prop_type = self.definition.get(name).get("type", "string")
+        definition = self.definition.get(name, None)
+        if definition is None:
+            logger.warn("No definition found for '%s'", name)
+            return False
+        prop_type = definition.get("type", "string")
         safe_value = value
         if value is not None:
             if prop_type == "proxy" and not isinstance(value, str):


### PR DESCRIPTION
Before, if we call `Simput.update` with a `changeset` that contained an undefined key we'd get the following error:

```
File ".../trame_simput/core/proxy.py", line 212, in set_property
    prop_type = self.definition.get(name).get("type", "string")
AttributeError: 'NoneType' object has no attribute 'get'
```

Which is not intuitive and the update stops at that point, losing the updates of all other keys that may be valid. I think we should just log a warning and continue.

Alternatively, we could also raise a proper error instead of the logger.warn.