### PR TITLE
fix(widgets):  Apply layout information on columns instead of rows

### DIFF
--- a/vue-components/src/widgets/TextField/template.html
+++ b/vue-components/src/widgets/TextField/template.html
@@ -43,13 +43,13 @@
     <v-col
       class="py-1"
       v-if="size != 1"
+      v-for="i in computedSize"
+      :key="i"
+      v-bind="getComponentProps(i-1)"
     >
       <v-row
         no-gutters
         class="align-center"
-        v-for="i in computedSize"
-        :key="i"
-        v-bind="getComponentProps(i-1)"
       >
         <v-text-field
           class="mt-0"


### PR DESCRIPTION
For the TextLayout widget, the layout information e.g. 'l2'/'l3' should be applied on the columns instead of the rows since it corresponds to grouping x number of entries __per__ line.

This PR fixes this issue.

However this  conflicts with 045433948748d4f5f9d842ae1c4482127520a727 . 

So maybe there is an alternative way to do it ?