### PR TITLE
fix(commit): ensure committed proxies have pending properties.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-
-# Just assume black did a good job with the line lengths
-ignore =
-    E501
-
-per-file-ignores =
-    # These directories will always contain "from ... import *"
-    trame/*:F401,F403

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,12 @@
 repos:
-  - repo: https://github.com/psf/black
-    rev: 22.3.0
-    hooks:
-      - id: black
-        entry: black --check
-
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0
     hooks:
       - id: codespell
 
-  - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.4
     hooks:
-      - id: flake8
+      - id: ruff
+      - id: ruff-format
+

--- a/trame/modules/simput.py
+++ b/trame/modules/simput.py
@@ -1,1 +1,1 @@
-from trame_simput.module import *
+from trame_simput.module import *  # noqa: F403

--- a/trame/widgets/simput.py
+++ b/trame/widgets/simput.py
@@ -1,4 +1,4 @@
-from trame_simput.widgets.simput import *
+from trame_simput.widgets.simput import *  # noqa: F403
 
 
 def initialize(server):

--- a/trame_simput/module/core.py
+++ b/trame_simput/module/core.py
@@ -252,6 +252,7 @@ class SimputController:
         if action == "commit":
             _ids = kwargs.get("ids", [])
             for _id in _ids:
-                self._pending_changeset.pop(_id)
+                if _id in self._pending_changeset:
+                    self._pending_changeset.pop(_id)
             self._server.state[self.changecount_key] = len(self.changeset)
             self._server.state[self.changeset_key] = self.changeset


### PR DESCRIPTION
The very first time we commit a change is committed via a simput widget
`_pending_changeset` holds the values of the edited widget while the `_ids`
holds all the proxies that haven't been committed so far. This yields an error
if there is a proxy in `_ids` but not in `_pending_changeset`.

The previous approach would assume that any non-committed proxy had pending
changes which is not true (at least in Async ParaView).  In Async ParaView,
proxies created without the UI like a render view has all its properties
already setup by the time the SimputWidget for the view is created so even
though is a "new" proxy, from simput's point of view there are no
pending_changes.

Other applications consuming `trame-simput` should not be affected negatively
since we just protect existing code that accessing a dictionary for missing
keys without any other restriction.


Depends on #25 