### PR TITLE
fix(release): update node version in release job

### DIFF
--- a/.github/workflows/test_and_release.yml
+++ b/.github/workflows/test_and_release.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Set Up Node
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 22
 
       - name: Build Vue2 Components
         run: |


### PR DESCRIPTION
The current ci is failing because https://github.com/Kitware/trame-simput/pull/25  updated nodejs version only in the test job but not the release job.